### PR TITLE
pin mkl=2020.0, add altair and threadpoolctl

### DIFF
--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -17,7 +17,7 @@ conda install --copy --yes -c conda-forge --override-channels \
     cmake \
     numpy \
     scipy \
-    mkl \
+    mkl=2020.0 \
     matplotlib \
     seaborn \
     pyyaml \
@@ -51,6 +51,8 @@ conda install --copy --yes -c conda-forge --override-channels \
     cupy \
     line_profiler \
     galsim \
+    altair \
+    vega_datasets \
 && conda install --copy --yes -c anaconda \
     intel-openmp \
 && mplrc="$CONDADIR/lib/python$PYVERSION/site-packages/matplotlib/mpl-data/matplotlibrc"; \

--- a/conf/pip-pkgs.sh
+++ b/conf/pip-pkgs.sh
@@ -2,6 +2,7 @@
 echo Installing pip packages at $(date)
 
 pip install --no-binary :all: hpsspy
+pip install threadpoolctl
 
 # see https://docs.nersc.gov/development/languages/python/parallel-python/
 MPICC="cc  -shared" pip install --force --no-cache-dir --no-binary=mpi4py mpi4py


### PR DESCRIPTION
This PR pins the MKL version to 2020.0 (which we have done in the past), which apparently is needed for strict reproducibility.  Pinning MKL also fixes (or at least hides/avoids) a segmentation fault with specex.

I also added [altair](https://altair-viz.github.io) and vega_datasets for future plotting experimentation, and threadpoolctl for debugging parallelism.

I ran an end-to-end test production with this branch and everthing worked in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/dc2/ .